### PR TITLE
support for include in jade

### DIFF
--- a/jade.js
+++ b/jade.js
@@ -5,9 +5,9 @@ module.exports = function(bundle){
   bundle.prepend(content)
 
   // Compiling templates.
-  bundle.register('.jade', function(data){
+  bundle.register('.jade', function(data, fileName){
     var jade = require('jade')
-    var content = jade.compile(data, {compileDebug: false, client: true})
+    var content = jade.compile(data, {compileDebug: false, client: true, filename:fileName})
     return "module.exports = " + content + ";"
   })
 }


### PR DESCRIPTION
jade.compile should be passed an option filename in order to understand which file it is compiled from.

Note: i use this solution in my project, but testing is up to you ;)
