### PR TITLE
Check for window.app

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var compile = function(file, data) {
   // It's usefull if you want to alter how template works, for example inject additional
   // variables.
   result.push("module.exports = function(variables){")
-  result.push("  if(window.app.__render) return window.app.__render(template, variables);")
+  result.push("  if(window.app && window.app.__render) return window.app.__render(template, variables);")
   result.push("  else return template(variables);")
   result.push("};")
 


### PR DESCRIPTION
I don't have `window.app` anywhere in my frontend code, so I get an error at runtime. This patch adds a check